### PR TITLE
Update login.service.js

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/login.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/login.service.js
@@ -317,11 +317,18 @@ export default function createLoginService(httpClient, context, bearerAuth = nul
 
     /**
      * Returns a CookieStorage instance with the right domain and path from the context.
-     *
      * @returns {CookieStorage}
      */
     function cookieStorageFactory() {
-        const domain = context.host;
+        let domain;
+
+        if (typeof window === 'object') {
+            domain = window.location.hostname;
+        } else {
+            const url = new URL(self.location.origin);
+            domain = url.hostname;
+        }
+
         const path = context.basePath + context.pathInfo;
 
         // Set default cookie values
@@ -334,7 +341,8 @@ export default function createLoginService(httpClient, context, bearerAuth = nul
             }
         );
     }
-
+    
+    
     /**
      * @deprecated 6.3.0
      * It resets the old localStorage implementation of the authentication.

--- a/src/Administration/Resources/app/administration/src/core/service/login.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/login.service.js
@@ -317,20 +317,13 @@ export default function createLoginService(httpClient, context, bearerAuth = nul
 
     /**
      * Returns a CookieStorage instance with the right domain and path from the context.
+     *
      * @returns {CookieStorage}
      */
     function cookieStorageFactory() {
-        let domain;
-
-        if (typeof window === 'object') {
-            domain = window.location.hostname;
-        } else {
-            const url = new URL(self.location.origin);
-            domain = url.hostname;
-        }
-
+        // take current domain instead of context to enable other hosts than "localhost"
+        const domain = window.location.hostname;
         const path = context.basePath + context.pathInfo;
-
         // Set default cookie values
         return new CookieStorage(
             {
@@ -341,8 +334,6 @@ export default function createLoginService(httpClient, context, bearerAuth = nul
             }
         );
     }
-    
-    
     /**
      * @deprecated 6.3.0
      * It resets the old localStorage implementation of the authentication.


### PR DESCRIPTION
Fixes login error with running administration watcher. If you use a different domain than "localhost" with your dev environment, the login will not work when you work in the backend with hot reload based on "bin/watch-administration.sh". This snippet is based on forum entry found here: https://forum.shopware.com/discussion/68312/admin-watch-login-geht-nicht-unter-version-6-2-0-rc1

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Administration watcher is not working, login stucks when using a different domain than "localhost"

### 2. What does this change do, exactly?
Enables the hot reload webpack server to work with other domains. Probably there should be an environment variable for this


### 3. Describe each step to reproduce the issue or behaviour.
* Run shopware dev environment under a custom domain (not localhost)
* start `bin/watch-administration.sh` to enable hot reloading
* try to login in the backend

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
